### PR TITLE
Add Plume EE plugin to CI

### DIFF
--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -135,6 +135,9 @@ name: downstream-ci-hpc
       plume:
         required: false
         type: string
+      plume-plugin-extreme-events:
+        required: false
+        type: string
       pyfdb:
         required: false
         type: string
@@ -250,6 +253,8 @@ jobs:
       pdbufr_matrix: ${{ steps.setup.outputs.pdbufr }}
       plume: ${{ steps.prepare-inputs.outputs.plume }}
       plume_matrix: ${{ steps.setup.outputs.plume }}
+      plume-plugin-extreme-events: ${{ steps.prepare-inputs.outputs.plume-plugin-extreme-events }}
+      plume-plugin-extreme-events_matrix: ${{ steps.setup.outputs.plume-plugin-extreme-events }}
       pyfdb: ${{ steps.prepare-inputs.outputs.pyfdb }}
       pyfdb_matrix: ${{ steps.setup.outputs.pyfdb }}
       pyodc: ${{ steps.prepare-inputs.outputs.pyodc }}
@@ -312,6 +317,7 @@ jobs:
         echo odc="${{ inputs.odc }}" >> $GITHUB_OUTPUT
         echo pdbufr="${{ inputs.pdbufr }}" >> $GITHUB_OUTPUT
         echo plume="${{ inputs.plume }}" >> $GITHUB_OUTPUT
+        echo plume-plugin-extreme-events="${{ inputs.plume-plugin-extreme-events }}" >> $GITHUB_OUTPUT
         echo pyfdb="${{ inputs.pyfdb }}" >> $GITHUB_OUTPUT
         echo pyodc="${{ inputs.pyodc }}" >> $GITHUB_OUTPUT
         echo skinnywms="${{ inputs.skinnywms }}" >> $GITHUB_OUTPUT
@@ -323,7 +329,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: ecmwf/downstream-ci
-        ref: main
+        ref: feature/add-plume-ee-plugin
     - name: Run setup script
       id: setup
       env:
@@ -618,6 +624,13 @@ jobs:
             master_branch: master
             develop_branch: develop
             input: ${{ steps.prepare-inputs.outputs.plume }}
+            optional_matrix: null
+          plume-plugin-extreme-events:ecmwf/plume-plugin-extreme-events:
+            path: .github/ci-hpc-config.yml
+            python: false
+            master_branch: main
+            develop_branch: develop
+            input: ${{ steps.prepare-inputs.outputs.plume-plugin-extreme-events }}
             optional_matrix: null
           pyfdb:ecmwf/pyfdb:
             path: .github/ci-hpc-config.yml
@@ -1994,6 +2007,30 @@ jobs:
           ${{ needs.setup.outputs.fckit }}
           ${{ needs.setup.outputs.eckit }}
           ${{ needs.setup.outputs.ecbuild }}
+        python_dependencies: ''
+  plume-plugin-extreme-events:
+    name: plume-plugin-extreme-events
+    needs:
+    - setup
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.plume-plugin-extreme-events_matrix && (needs.setup.outputs.plume-plugin-extreme-events)&& contains(fromJson(needs.setup.outputs.ci_group_pkgs), 'plume-plugin-extreme-events') }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup.outputs.plume-plugin-extreme-events_matrix) }}
+    env:
+      DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on:
+    - self-hosted
+    - linux
+    - hpc
+    steps:
+    - uses: ecmwf/reusable-workflows/ci-hpc@v2
+      with:
+        github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
+        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
+        troika_user: ${{ secrets.HPC_CI_SSH_USER }}
+        repository: ${{ matrix.owner_repo_ref }}
+        build_config: ${{ matrix.config_path }}
+        dependencies: ''
         python_dependencies: ''
   pyfdb:
     name: pyfdb

--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -139,6 +139,9 @@ name: downstream-ci
       plume:
         required: false
         type: string
+      plume-plugin-extreme-events:
+        required: false
+        type: string
       pyfdb:
         required: false
         type: string
@@ -266,6 +269,8 @@ jobs:
       pdbufr_matrix: ${{ steps.setup.outputs.pdbufr }}
       plume: ${{ steps.prepare-inputs.outputs.plume }}
       plume_matrix: ${{ steps.setup.outputs.plume }}
+      plume-plugin-extreme-events: ${{ steps.prepare-inputs.outputs.plume-plugin-extreme-events }}
+      plume-plugin-extreme-events_matrix: ${{ steps.setup.outputs.plume-plugin-extreme-events }}
       pyfdb: ${{ steps.prepare-inputs.outputs.pyfdb }}
       pyfdb_matrix: ${{ steps.setup.outputs.pyfdb }}
       pyodc: ${{ steps.prepare-inputs.outputs.pyodc }}
@@ -331,6 +336,7 @@ jobs:
         echo odc="${{ inputs.odc }}" >> $GITHUB_OUTPUT
         echo pdbufr="${{ inputs.pdbufr }}" >> $GITHUB_OUTPUT
         echo plume="${{ inputs.plume }}" >> $GITHUB_OUTPUT
+        echo plume-plugin-extreme-events="${{ inputs.plume-plugin-extreme-events }}" >> $GITHUB_OUTPUT
         echo pyfdb="${{ inputs.pyfdb }}" >> $GITHUB_OUTPUT
         echo pyodc="${{ inputs.pyodc }}" >> $GITHUB_OUTPUT
         echo skinnywms="${{ inputs.skinnywms }}" >> $GITHUB_OUTPUT
@@ -342,7 +348,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: ecmwf/downstream-ci
-        ref: main
+        ref: feature/add-plume-ee-plugin
     - name: Run setup script
       id: setup
       env:
@@ -637,6 +643,13 @@ jobs:
             master_branch: master
             develop_branch: develop
             input: ${{ steps.prepare-inputs.outputs.plume }}
+            optional_matrix: null
+          plume-plugin-extreme-events:ecmwf/plume-plugin-extreme-events:
+            path: .github/ci-config.yml
+            python: false
+            master_branch: main
+            develop_branch: develop
+            input: ${{ steps.prepare-inputs.outputs.plume-plugin-extreme-events }}
             optional_matrix: null
           pyfdb:ecmwf/pyfdb:
             path: .github/ci-config.yml
@@ -2109,6 +2122,27 @@ jobs:
           ${{ needs.setup.outputs.fckit }}
           ${{ needs.setup.outputs.eckit }}
           ${{ needs.setup.outputs.ecbuild }}
+        codecov_token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
+        codecov_upload: ${{ contains(needs.setup.outputs.trigger_pkgs, github.job) && inputs.codecov_upload }}
+  plume-plugin-extreme-events:
+    name: plume-plugin-extreme-events
+    needs:
+    - setup
+    - clang-format
+    if: ${{ (always() && !cancelled()) && contains(join(needs.*.result, ','), 'success') && needs.setup.outputs.plume-plugin-extreme-events_matrix && (needs.setup.outputs.plume-plugin-extreme-events)&& contains(fromJson(needs.setup.outputs.ci_group_pkgs), 'plume-plugin-extreme-events') }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup.outputs.plume-plugin-extreme-events_matrix) }}
+    env:
+      DEP_TREE: ${{ needs.setup.outputs.dep_tree }}
+    runs-on: ${{ matrix.labels }}
+    steps:
+    - uses: ecmwf/reusable-workflows/build-package-with-config@v2
+      with:
+        repository: ${{ matrix.owner_repo_ref }}
+        build_package_inputs: 'repository: ${{ matrix.owner_repo_ref }}'
+        build_config: ${{ matrix.config_path }}
+        build_dependencies: ''
         codecov_token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
         codecov_upload: ${{ contains(needs.setup.outputs.trigger_pkgs, github.job) && inputs.codecov_upload }}
   pyfdb:

--- a/dependency_tree.yml
+++ b/dependency_tree.yml
@@ -470,6 +470,10 @@ plume:
     - atlas
     - fckit
 
+plume-plugin-extreme-events:
+  type: cmake
+  master_branch: main
+
 pyfdb:
   type: python
   deps:


### PR DESCRIPTION
Here is a PR to add the extreme event detection Plume plugin to the downstream CI. No dependency is listed as we do not want it to be picked up by the downstream ci of other packages until it is in a more stable state.

Question: I see in the automatic commit that these lines were changed
```
 -      ref: main
 +      ref: feature/add-plume-ee-plugin
```
Is this correct ?