### PR TITLE
Earthkit regrid disable FINDLIBS_DISABLE_PACKAGE

### DIFF
--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -353,7 +353,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: ecmwf/downstream-ci
-        ref: main
+        ref: feature/earthkit-regrid-use-FINDLIBS-DISABLE-PACKAGE=no
     - name: Run setup script
       id: setup
       env:

--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -372,7 +372,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: ecmwf/downstream-ci
-        ref: main
+        ref: feature/earthkit-regrid-use-FINDLIBS-DISABLE-PACKAGE=no
     - name: Run setup script
       id: setup
       env:
@@ -1212,6 +1212,9 @@ jobs:
         checkout: true
         python_dependencies: ''
         requirements_path: tests/downstream-ci-requirements.txt
+        test_cmd: |
+          FINDLIBS_DISABLE_PACKAGE=no pytest --cov=./ --cov-report=xml
+          FINDLIBS_DISABLE_PACKAGE=no python -m coverage report
         codecov_upload: ${{ contains(needs.setup.outputs.trigger_pkgs, github.job) && inputs.codecov_upload && needs.setup.outputs.py_codecov_platform == matrix.name }}
         codecov_token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
   earthkit-time:

--- a/dependency_tree.yml
+++ b/dependency_tree.yml
@@ -75,6 +75,9 @@ earthkit-regrid:
   requirements_path: tests/downstream-ci-requirements.txt
   downstream-ci:
     config_path: ""
+    test_cmd: |
+      FINDLIBS_DISABLE_PACKAGE=no pytest --cov=./ --cov-report=xml
+      FINDLIBS_DISABLE_PACKAGE=no python -m coverage report
 
 earthkit-time:
   type: python


### PR DESCRIPTION
This is needed to make mir-python work in the earthkit-regrid ci