### PR TITLE
Remove netcdf from ek data tests

### DIFF
--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -353,7 +353,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: ecmwf/downstream-ci
-        ref: main
+        ref: remove-netcdf-from-ek-data-tests
     - name: Run setup script
       id: setup
       env:

--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -1144,9 +1144,9 @@ jobs:
           ${{ needs.setup.outputs.earthkit-utils || (needs.setup.outputs.use_master == 'True' && 'earthkit-utils:ecmwf/earthkit-utils@main') || 'earthkit-utils:ecmwf/earthkit-utils@develop' }}
         toml_opt_dep_sections: all,test,ci
         test_cmd: |
-          python -m pytest -vv -m 'not notebook and not no_cache_init' --cov=. --cov-report=xml
+          python -m pytest -vv -m 'not notebook and not no_cache_init' -k 'not netcdf' --cov=. --cov-report=xml
           python -m pytest -v -m 'notebook'
-          python -m pytest --forked -vv -m 'no_cache_init'
+          python -m pytest --forked -vv -m 'no_cache_init' -k 'not netcdf'
           python -m coverage report
         codecov_upload: ${{ contains(needs.setup.outputs.trigger_pkgs, github.job) && inputs.codecov_upload && needs.setup.outputs.py_codecov_platform == matrix.name }}
         codecov_token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}

--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -372,7 +372,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: ecmwf/downstream-ci
-        ref: main
+        ref: remove-netcdf-from-ek-data-tests
     - name: Run setup script
       id: setup
       env:

--- a/dependency_tree.yml
+++ b/dependency_tree.yml
@@ -48,9 +48,9 @@ earthkit-data:
     - earthkit-utils
   downstream-ci:
     test_cmd: |
-      python -m pytest -vv -m 'not notebook and not no_cache_init' --cov=. --cov-report=xml
+      python -m pytest -vv -m 'not notebook and not no_cache_init' -k 'not netcdf' --cov=. --cov-report=xml
       python -m pytest -v -m 'notebook'
-      python -m pytest --forked -vv -m 'no_cache_init'
+      python -m pytest --forked -vv -m 'no_cache_init' -k 'not netcdf'
       python -m coverage report
 
 earthkit-geo:


### PR DESCRIPTION
### Description

This is temporary, but currently there seems to be a threading issue where occasionally a test that uses netcdf through xarray/dask has a threading issue that either causes the test to fail or to hang. The latter is worse because it means that a runner is consumed until the workflow is cancelled. This is a temporary fix to avoid running any netcdf-based tests in the ci until this is somehow fixed.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 