### PR TITLE
Setup additional compiler toolchains

### DIFF
--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -583,8 +583,10 @@ jobs:
             - clang@macos-13-x86
             - gnu@debian-12
             - gnu-14.2.0
+            - gnu-15.2.0
             - nvidia-24.11
             - intel-2025.0.1
+            - intel-2025.3.1
           ecflow-light:ecmwf/ecflow-light:
             path: .github/ci-hpc-config.yml
             python: false
@@ -850,6 +852,13 @@ jobs:
             compiler_modules: gcc/14.2.0
             name: gnu-14.2.0
             site: atos
+          - compiler: gnu-15.2.0
+            compiler_cc: gcc
+            compiler_cxx: g++
+            compiler_fc: gfortran
+            compiler_modules: gcc/15.2.0
+            name: gnu-15.2.0
+            site: atos
           - compiler: nvidia-24.11
             compiler_cc: nvc
             compiler_cxx: nvc++
@@ -864,6 +873,13 @@ jobs:
             compiler_modules: prgenv/intel-llvm,intel/2025.0.1
             name: intel-2025.0.1
             site: atos
+          - compiler: intel-2025.3.1
+            compiler_cc: icx
+            compiler_cxx: icpx
+            compiler_fc: ifx
+            compiler_modules: prgenv/intel-llvm,intel/2025.3.1
+            name: intel-2025.3.1
+            site: atos
           - compiler: aocc-4.0.0
             compiler_cc: clang
             compiler_cxx: clang++
@@ -874,8 +890,10 @@ jobs:
           name:
           - lumi
           - gnu-14.2.0
+          - gnu-15.2.0
           - nvidia-24.11
           - intel-2025.0.1
+          - intel-2025.3.1
           - aocc-4.0.0
         WORKFLOW_NAME: downstream-ci-hpc
         DOWNSTREAM_CI_GROUP: ${{ inputs.ci_group }}

--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -384,7 +384,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: ecmwf/downstream-ci
-        ref: main
+        ref: task/additional_compiler_toolchains
     - name: Run setup script
       id: setup
       env:
@@ -582,8 +582,8 @@ jobs:
             - clang@macos-13-arm
             - clang@macos-13-x86
             - gnu@debian-12
-            - gnu-14.2.0
             - gnu-15.2.0
+            - gnu-14.2.0
             - nvidia-24.11
             - intel-2025.0.1
             - intel-2025.3.1

--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -403,7 +403,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: ecmwf/downstream-ci
-        ref: main
+        ref: task/additional_compiler_toolchains
     - name: Run setup script
       id: setup
       env:
@@ -601,6 +601,11 @@ jobs:
             - clang@macos-13-arm
             - clang@macos-13-x86
             - gnu@debian-12
+            - gnu-15.2.0
+            - gnu-14.2.0
+            - nvidia-24.11
+            - intel-2025.0.1
+            - intel-2025.3.1
           ecflow-light:ecmwf/ecflow-light:
             path: .github/ci-config.yml
             python: false

--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -601,9 +601,6 @@ jobs:
             - clang@macos-13-arm
             - clang@macos-13-x86
             - gnu@debian-12
-            - gnu-14.2.0
-            - nvidia-24.11
-            - intel-2025.0.1
           ecflow-light:ecmwf/ecflow-light:
             path: .github/ci-config.yml
             python: false

--- a/config.yml
+++ b/config.yml
@@ -159,8 +159,10 @@ downstream-ci-hpc: &downstream_ci_hpc
     name:
     - lumi
     - gnu-14.2.0
+    - gnu-15.2.0
     - nvidia-24.11
     - intel-2025.0.1
+    - intel-2025.3.1
     - aocc-4.0.0
     include:
     - name: lumi-gnu-12.2.0
@@ -177,6 +179,13 @@ downstream-ci-hpc: &downstream_ci_hpc
       compiler_cxx: g++
       compiler_fc: gfortran
       compiler_modules: gcc/14.2.0
+    - name: gnu-15.2.0
+      site: atos
+      compiler: gnu-15.2.0
+      compiler_cc: gcc
+      compiler_cxx: g++
+      compiler_fc: gfortran
+      compiler_modules: gcc/15.2.0
     - name: nvidia-24.11
       site: atos
       compiler: nvidia-24.11
@@ -191,6 +200,13 @@ downstream-ci-hpc: &downstream_ci_hpc
       compiler_cxx: icpx
       compiler_fc: ifx
       compiler_modules: prgenv/intel-llvm,intel/2025.0.1
+    - name: intel-2025.3.1
+      site: atos
+      compiler: intel-2025.3.1
+      compiler_cc: icx
+      compiler_cxx: icpx
+      compiler_fc: ifx
+      compiler_modules: prgenv/intel-llvm,intel/2025.3.1
     - name: aocc-4.0.0
       site: atos
       compiler: aocc-4.0.0

--- a/dependency_tree.yml
+++ b/dependency_tree.yml
@@ -305,9 +305,11 @@ ecflow:
   - clang@macos-13-arm
   - clang@macos-13-x86
   - gnu@debian-12
+  - gnu-15.2.0
   - gnu-14.2.0
   - nvidia-24.11
   - intel-2025.0.1
+  - intel-2025.3.1
 
 ecflow-light:
   type: cmake


### PR DESCRIPTION
### Description

This PR enables the following additional compiler toolchains for the HPC CI builds:
 - GNU GCC 15.2.0
 - Intel 2025.3.1

In particular, this allows using these compiler toolchains in the ecflow CI builds -- see https://github.com/ecmwf/ecflow/pull/320.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 