### PR TITLE
task: add intel-2021.4.0 to the ecflow CI

### DIFF
--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -384,7 +384,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: ecmwf/downstream-ci
-        ref: main
+        ref: task/additional_compiler_toolchains
     - name: Run setup script
       id: setup
       env:
@@ -585,7 +585,6 @@ jobs:
             - gnu-15.2.0
             - gnu-14.2.0
             - nvidia-24.11
-            - intel-2021.4.0
             - intel-2025.0.1
             - intel-2025.3.1
           ecflow-light:ecmwf/ecflow-light:

--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -585,6 +585,7 @@ jobs:
             - gnu-15.2.0
             - gnu-14.2.0
             - nvidia-24.11
+            - intel-2021.4.0
             - intel-2025.0.1
             - intel-2025.3.1
           ecflow-light:ecmwf/ecflow-light:

--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -403,7 +403,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: ecmwf/downstream-ci
-        ref: main
+        ref: task/additional_compiler_toolchains
     - name: Run setup script
       id: setup
       env:


### PR DESCRIPTION
### Description

Since intel-2021.4.0 is used by default when projects upstream of ecflow (e.g. ecbuild), having this compiler in the project CI ensures awareness of any potential failure.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
