### PR TITLE
update conda deps for danu

### DIFF
--- a/.github/workflows/downstream-ci-hpc.yml
+++ b/.github/workflows/downstream-ci-hpc.yml
@@ -378,7 +378,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: ecmwf/downstream-ci
-        ref: main
+        ref: fix/update-danu-conda-deps
     - name: Run setup script
       id: setup
       env:
@@ -2676,4 +2676,4 @@ jobs:
         dependencies: ''
         python_dependencies: ''
         python_requirements: requirements.txt
-        conda_deps: '''numpy<2'' scipy pcraster gdal netCDF4 pandas dask lz4 eccodes magics'
+        conda_deps: '''numpy<2.4'' scipy pcraster=4.4.2 libjxl=0.11 gdal libnetcdf ''netcdf4<=1.7.2'' magics rasterio bottleneck pyproj numba'

--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -397,7 +397,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: ecmwf/downstream-ci
-        ref: main
+        ref: fix/update-danu-conda-deps
     - name: Run setup script
       id: setup
       env:
@@ -2765,6 +2765,6 @@ jobs:
         python_dependencies: ''
         requirements_path: requirements.txt
         test_cmd: python -m pytest
-        conda_install: '''numpy<2'' scipy pcraster gdal netCDF4 pandas dask lz4 eccodes magics'
+        conda_install: '''numpy<2.4'' scipy pcraster=4.4.2 libjxl=0.11 gdal libnetcdf ''netcdf4<=1.7.2'' magics rasterio bottleneck pyproj numba'
         codecov_upload: ${{ contains(needs.setup.outputs.trigger_pkgs, github.job) && inputs.codecov_upload && needs.setup.outputs.py_codecov_platform == matrix.name }}
         codecov_token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}

--- a/dependency_tree.yml
+++ b/dependency_tree.yml
@@ -625,7 +625,7 @@ danu:
   master_branch: main
   requirements_path: requirements.txt
   test_cmd: "python -m pytest"
-  conda_deps: "'numpy<2' scipy pcraster gdal netCDF4 pandas dask lz4 eccodes magics"
+  conda_deps: "'numpy<2.4' scipy pcraster=4.4.2 libjxl=0.11 gdal libnetcdf 'netcdf4<=1.7.2' magics rasterio bottleneck pyproj numba"
   downstream-ci:
     config_path: ""
   downstream-ci-hpc:


### PR DESCRIPTION
### Description
This pull request updates the dependency configuration in the `dependency_tree.yml` file to better control package versions and add new required dependencies for the project. Align it to current state for danu@develop and python version (3.13)

**Dependency updates:**

* Updated the `conda_deps` list to specify more precise versions for several packages (e.g., `'numpy<2.4'`, `pcraster=4.4.2`, `libjxl=0.11`, `'netcdf4<=1.7.2'`) and added new dependencies (`libjxl`, `libnetcdf`, `rasterio`, `bottleneck`, `pyproj`, `numba`). Some previously listed packages (`pandas`, `dask`, `lz4`, `eccodes`) were removed.

It should also fix current CI runs in danu, for instance:

https://github.com/ecmwf/danu/actions/runs/28801635647/job/85406378628

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
